### PR TITLE
Removal of master/slave lingo

### DIFF
--- a/bundle/YouCompleteMe/third_party/pythonfutures/docs/conf.py
+++ b/bundle/YouCompleteMe/third_party/pythonfutures/docs/conf.py
@@ -33,8 +33,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'futures'

--- a/bundle/YouCompleteMe/third_party/requests/docs/conf.py
+++ b/bundle/YouCompleteMe/third_party/requests/docs/conf.py
@@ -41,8 +41,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Requests'

--- a/bundle/YouCompleteMe/third_party/ycmd/third_party/argparse/doc/source/conf.py
+++ b/bundle/YouCompleteMe/third_party/ycmd/third_party/argparse/doc/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'argparse'

--- a/bundle/YouCompleteMe/third_party/ycmd/third_party/bottle/docs/conf.py
+++ b/bundle/YouCompleteMe/third_party/ycmd/third_party/bottle/docs/conf.py
@@ -7,7 +7,7 @@ sys.path.insert(0, bottle_dir)
 import bottle
 
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.viewcode']
-master_doc = 'index'
+main_doc = 'index'
 project = u'Bottle'
 copyright = u'2009-%s, %s' % (time.strftime('%Y'), bottle.__author__)
 version = ".".join(bottle.__version__.split(".")[:2])

--- a/bundle/YouCompleteMe/third_party/ycmd/third_party/jedi/docs/conf.py
+++ b/bundle/YouCompleteMe/third_party/ycmd/third_party/jedi/docs/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Jedi'

--- a/bundle/YouCompleteMe/third_party/ycmd/third_party/requests/docs/conf.py
+++ b/bundle/YouCompleteMe/third_party/ycmd/third_party/requests/docs/conf.py
@@ -41,8 +41,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Requests'

--- a/bundle/YouCompleteMe/third_party/ycmd/third_party/waitress/docs/conf.py
+++ b/bundle/YouCompleteMe/third_party/ycmd/third_party/waitress/docs/conf.py
@@ -33,7 +33,7 @@ if 'sphinx-build' in ' '.join(sys.argv): # protect against dumb importers
                 '_themes'])
     else:
         os.chdir(_themes)
-        call([git, 'checkout', 'master'])
+        call([git, 'checkout', 'main'])
         call([git, 'pull'])
         os.chdir(cwd)
 
@@ -54,8 +54,8 @@ templates_path = ['_templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General substitutions.
 project = 'waitress'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.